### PR TITLE
Remove --save flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A markdown proofing platform for individuals, teams, and organizations.
 Install into your project:
 
 ```
-> npm install markdown-proofing --save
+> npm install markdown-proofing
 ```
 
 Now, create a `.markdown-proofing` JSON file in the root of your project. Here's a simple one using a preset to get started:


### PR DESCRIPTION
Users of the package may want to use this as a `dependency`, a `devDependency`, or global install. We should leave it up to them.