### PR TITLE
Describe/use custom analyzer wireup

### DIFF
--- a/.markdown-proofing
+++ b/.markdown-proofing
@@ -3,6 +3,7 @@
     "info-everything"
   ],
   "analyzers": [
+    "../../lib/analyzers/spelling"
   ],
   "rules": {
     "spelling-error": "error",

--- a/README.md
+++ b/README.md
@@ -107,10 +107,20 @@ export default class MyCustomAnalyzerAnalyzer {
 }
 ```
 
-Then, simply wire it up!
+Then, simply wire it up in configuration as an `analyzers` array item:
 
-```
-TODO
+```json
+{
+  "presets": [
+  ],
+  "analyzers": [
+    "path/to/custom-analyzer"
+  ],
+  "rules": {
+    "custom-analyzer-message": "info"
+  }
+}
+
 ```
 
 ## Author


### PR DESCRIPTION
The custom analyzer usage is a duplicate usage of `SpellingAnalyzer` in **.markdown-proofing**, which is used with `npm run integration-test`.