### PR TITLE
Fix paths when using package in a node_modules fashion

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,10 +1,6 @@
 #! /usr/bin/env node
 'use strict';
 
-var _appRootPath = require('app-root-path');
-
-var _appRootPath2 = _interopRequireDefault(_appRootPath);
-
 var _meow = require('meow');
 
 var _meow2 = _interopRequireDefault(_meow);
@@ -27,9 +23,9 @@ var _main2 = _interopRequireDefault(_main);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-/* eslint-disable no-console */
+var defaultConfigurationPath = '.markdown-proofing';
 
-var defaultConfigurationPath = '/.markdown-proofing';
+/* eslint-disable no-console */
 
 var cli = (0, _meow2.default)({
   help: ['Usage', '  $ markdown-proofing [...file-glob]', '', 'Options', '  -c, --configuration  Specify a configuration file to use. [Default: .markdown-proofing]', '  -n, --no-colors      Do not apply colors to the output.   [Default: false]', '', 'Examples', '  $ markdown-proofing ./file1.md', '  Analyze ./file1.md file', '  $ markdown-proofing ./file1.md ./file2.md', '  Analyze ./file1.md and ./file2.md files', '  $ markdown-proofing -c ./custom-configuration.json ./file1.md', '  Analyze ./file.md file using ./custom-configuration.json', '  $ markdown-proofing **/*.md', '  Analyze all .md files recursively'],
@@ -51,7 +47,7 @@ if (!cli.input || cli.input.length === 0) {
 // Create markdownProofing using configuration file from disk
 //
 
-var filePath = _appRootPath2.default.resolve(flags.configuration || defaultConfigurationPath);
+var filePath = flags.configuration || defaultConfigurationPath;
 
 try {
   _fs2.default.accessSync(filePath, _fs2.default.F_OK);

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "dependencies": {
     "alex": "^2.0.0",
-    "app-root-path": "^1.0.0",
     "buzzwords": "^1.0.1",
     "chalk": "^1.1.1",
     "ensure-oxford-commas": "^0.1.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,6 @@
 
 /* eslint-disable no-console */
 
-import appRootPath from 'app-root-path';
 import meow from 'meow';
 import chalk from 'chalk';
 import glob from 'glob';
@@ -10,7 +9,7 @@ import fs from 'fs';
 
 import MarkdownProofing from './lib/main';
 
-const defaultConfigurationPath = '/.markdown-proofing';
+const defaultConfigurationPath = '.markdown-proofing';
 
 const cli = meow({
   help: [
@@ -49,7 +48,7 @@ if (!cli.input || cli.input.length === 0) {
 // Create markdownProofing using configuration file from disk
 //
 
-const filePath = appRootPath.resolve(flags.configuration || defaultConfigurationPath);
+const filePath = flags.configuration || defaultConfigurationPath;
 
 try {
   fs.accessSync(filePath, fs.F_OK);

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -1,4 +1,3 @@
-import appRootPath from 'app-root-path';
 import fs from 'fs';
 import Rule from './rule';
 
@@ -8,30 +7,30 @@ export default class MarkdownProofing {
     this.rules = [];
   }
 
-  // The `rootFolder` parameter helps with testing
-  static createUsingConfiguration(configuration, rootFolder = '/lib') {
+  // The `rootDirOverride` parameter helps with testing
+  static createUsingConfiguration(configuration, rootDirOverride) {
     const markdownProofing = new MarkdownProofing();
 
     if (configuration.presets) {
       configuration.presets.forEach(x => {
-        const presetFilePath = appRootPath.resolve(`${rootFolder}/presets/${x}.json`);
+        const presetFilePath = `${rootDirOverride || __dirname}/presets/${x}.json`;
         const presetConfiguration = JSON.parse(fs.readFileSync(presetFilePath, 'utf-8'));
 
         this.addAssetsToInstance(
-          markdownProofing, presetConfiguration, rootFolder);
+          markdownProofing, presetConfiguration, rootDirOverride);
       });
     }
 
     this.addAssetsToInstance(
-      markdownProofing, configuration, rootFolder);
+      markdownProofing, configuration, rootDirOverride);
 
     return markdownProofing;
   }
 
-  static addAssetsToInstance(markdownProofing, configuration, rootFolder) {
+  static addAssetsToInstance(markdownProofing, configuration, rootDirOverride) {
     if (configuration.analyzers) {
       configuration.analyzers.forEach(x => {
-        const analyzer = require(appRootPath.resolve(`${rootFolder}/analyzers/${x}.js`));
+        const analyzer = require(`${rootDirOverride || __dirname}/analyzers/${x}.js`);
         markdownProofing.addAnalyzer(analyzer);
       });
     }

--- a/test/main.js
+++ b/test/main.js
@@ -3,6 +3,8 @@ import test from 'ava';
 import MarkdownProofing from '../src/lib/main';
 import AnalyzerResult from '../src/lib/analyzer-result';
 
+const rootDirOverride = __dirname + '/../src/lib';
+
 class TestAnalyzer1 {
   analyze(/* str */) {
     const result = new AnalyzerResult();
@@ -184,7 +186,7 @@ test('createUsingConfiguration adds analyzers', t => {
     ]
   };
 
-  const proofing = MarkdownProofing.createUsingConfiguration(configuration, '/src/lib');
+  const proofing = MarkdownProofing.createUsingConfiguration(configuration, rootDirOverride);
 
   t.is(proofing.analyzers.length, 2);
 });
@@ -196,7 +198,7 @@ test('createUsingConfiguration adds rules', t => {
     }
   };
 
-  const proofing = MarkdownProofing.createUsingConfiguration(configuration, '/src/lib');
+  const proofing = MarkdownProofing.createUsingConfiguration(configuration, rootDirOverride);
 
   t.is(proofing.rules.length, 1);
 });
@@ -208,7 +210,7 @@ test('createUsingConfiguration presets adds preset analyzers', t => {
     ]
   };
 
-  const proofing = MarkdownProofing.createUsingConfiguration(configuration, '/src/lib');
+  const proofing = MarkdownProofing.createUsingConfiguration(configuration, rootDirOverride);
 
   t.true(proofing.analyzers.length > 1);
 });
@@ -220,7 +222,7 @@ test('createUsingConfiguration presets adds preset rules', t => {
     ]
   };
 
-  const proofing = MarkdownProofing.createUsingConfiguration(configuration, '/src/lib');
+  const proofing = MarkdownProofing.createUsingConfiguration(configuration, rootDirOverride);
 
   t.true(proofing.rules.length > 1);
 });
@@ -235,7 +237,7 @@ test('createUsingConfiguration removes rules from preset with none', t => {
     }
   };
 
-  const proofing = MarkdownProofing.createUsingConfiguration(configuration, '/src/lib');
+  const proofing = MarkdownProofing.createUsingConfiguration(configuration, rootDirOverride);
 
   t.false(proofing.rules.some(x => x.messageType === 'spelling-error'));
 });


### PR DESCRIPTION
These changes were discovered as necessary when testing the package generated by `npm pack` in another repository locally.