### PR TITLE
Fix lint errors

### DIFF
--- a/test/main.js
+++ b/test/main.js
@@ -1,9 +1,10 @@
 import test from 'ava';
+import path from 'path';
 
 import MarkdownProofing from '../src/lib/main';
 import AnalyzerResult from '../src/lib/analyzer-result';
 
-const rootDirOverride = __dirname + '/../src/lib';
+const rootDirOverride = path.join(__dirname, '/../src/lib');
 
 class TestAnalyzer1 {
   analyze(/* str */) {


### PR DESCRIPTION
Fix the following lint errors:

```
  6:25  error  Use path.join() or path.resolve() instead of + to create paths  no-path-concat
  6:25  error  Unexpected string concatenation                                 prefer-template
```