### PR TITLE
Support comma seperated configuration, fix CLI condition output, remove invalid tests

### DIFF
--- a/.markdown-proofing
+++ b/.markdown-proofing
@@ -3,11 +3,12 @@
     "info-everything"
   ],
   "analyzers": [
-    "../../lib/analyzers/spelling"
+    "../../lib/analyzers/spelling",
+    "statistics"
   ],
   "rules": {
     "spelling-error": "error",
     "statistics-flesch-kincaid-reading-ease": "warning <= 40",
-    "statistics-flesch-kincaid-grade-level": "warning > 12"
+    "statistics-flesch-kincaid-grade-level": "info, warning > 12"
   }
 }

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ Or, a bit more complex:
     "sentiment-score": "info",
     "sentiment-comparative-score": "info",
     "spelling-error": "error",
-    "statistics-flesch-kincaid-grade-level": "info",
-    "statistics-flesch-kincaid-grade-level": "warning > 12",
+    "statistics-flesch-kincaid-grade-level": "info, warning > 12",
     "statistics-flesch-kincaid-reading-ease": "warning <= 40",
     "write-good": "info"
   }

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -58,7 +58,16 @@ export default class MarkdownProofing {
   }
 
   addRule(messageType, ruleCondition) {
-    this.rules.push(new Rule(messageType, ruleCondition));
+    // ruleCondition could be:
+    // info, warning < 5, error < 10
+    //
+    // We should apply each of these as a separate rule.
+
+    const ruleConditions = ruleCondition.split(',').map(x => x.trim());
+
+    ruleConditions.forEach(rc => {
+      this.rules.push(new Rule(messageType, rc));
+    });
 
     return this;
   }

--- a/src/lib/presets/technical-blog.json
+++ b/src/lib/presets/technical-blog.json
@@ -18,10 +18,8 @@
     "sensitivity": "warning",
     "spelling-error": "error",
     "statistics-estimated-read-time": "info",
-    "statistics-flesch-kincaid-reading-ease": "info",
-    "statistics-flesch-kincaid-reading-ease": "warning < 40",
-    "statistics-flesch-kincaid-grade-level": "info",
-    "statistics-flesch-kincaid-grade-level": "warning > 12",
+    "statistics-flesch-kincaid-reading-ease": "info, warning < 40",
+    "statistics-flesch-kincaid-grade-level": "info, warning > 12",
     "write-good": "info"
   }
 }

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,22 @@
+import test from 'ava';
+
+test('TODO', t => {
+  t.pass();
+});
+
+/*
+test('Returns expected error when warning exists applying error first', t => {
+});
+
+test('Returns expected error when warning exists applying warning first', t => {
+});
+
+test('Returns expected error when info rule condition exists', t => {
+});
+
+test('Returns expected error when warning and info rule conditions exist', t => {
+});
+
+test('Returns expected warning when info rule condition exists', t => {
+});
+*/

--- a/test/main.js
+++ b/test/main.js
@@ -72,7 +72,7 @@ test('Returns expected single message with one analyzer added twice with matchin
     });
 });
 
-test('Returns expected one message from two analyzers with one matching configuration rules', t => {
+test('Returns expected single message from two analyzers with one matching configuration rules', t => {
   const text = 'a';
 
   return new MarkdownProofing()
@@ -108,13 +108,12 @@ test('Returns expected two messages from two analyzers with two matching configu
     });
 });
 
-test('Returns expected error when warning exists applying error first', t => {
+test('Returns single message for multiple rule conditions', t => {
   const text = 'a';
 
   return new MarkdownProofing()
     .addAnalyzer(TestAnalyzer1)
-    .addRule('test-analyzer-1', 'error')
-    .addRule('test-analyzer-1', 'warning')
+    .addRule('test-analyzer-1', 'info, warning')
     .proof(text)
     .then(result => {
       t.is(result.messages.length, 1);
@@ -122,61 +121,14 @@ test('Returns expected error when warning exists applying error first', t => {
     });
 });
 
-test('Returns expected error when warning exists applying warning first', t => {
-  const text = 'a';
-
-  return new MarkdownProofing()
+test('Sets two rules when comma seperated', t => {
+  const sut = new MarkdownProofing()
     .addAnalyzer(TestAnalyzer1)
-    .addRule('test-analyzer-1', 'warning')
-    .addRule('test-analyzer-1', 'error')
-    .proof(text)
-    .then(result => {
-      t.is(result.messages.length, 1);
-      t.is(result.messages[0].type, 'test-analyzer-1');
-    });
-});
+    .addRule('test-analyzer-1', 'info, warning < 10');
 
-test('Returns expected error when info rule condition exists', t => {
-  const text = 'a';
-
-  return new MarkdownProofing()
-    .addAnalyzer(TestAnalyzer1)
-    .addRule('test-analyzer-1', 'error')
-    .addRule('test-analyzer-1', 'info')
-    .proof(text)
-    .then(result => {
-      t.is(result.messages.length, 1);
-      t.is(result.messages[0].type, 'test-analyzer-1');
-    });
-});
-
-test('Returns expected error when warning and info rule conditions exist', t => {
-  const text = 'a';
-
-  return new MarkdownProofing()
-    .addAnalyzer(TestAnalyzer1)
-    .addRule('test-analyzer-1', 'error')
-    .addRule('test-analyzer-1', 'warning')
-    .addRule('test-analyzer-1', 'info')
-    .proof(text)
-    .then(result => {
-      t.is(result.messages.length, 1);
-      t.is(result.messages[0].type, 'test-analyzer-1');
-    });
-});
-
-test('Returns expected warning when info rule condition exists', t => {
-  const text = 'a';
-
-  return new MarkdownProofing()
-    .addAnalyzer(TestAnalyzer1)
-    .addRule('test-analyzer-1', 'info')
-    .addRule('test-analyzer-1', 'warning')
-    .proof(text)
-    .then(result => {
-      t.is(result.messages.length, 1);
-      t.is(result.messages[0].type, 'test-analyzer-1');
-    });
+  t.is(sut.rules.length, 2);
+  t.is(sut.rules[0].condition, 'info');
+  t.is(sut.rules[1].condition, 'warning < 10');
 });
 
 test('createUsingConfiguration adds analyzers', t => {


### PR DESCRIPTION
- Support `info, warning < 5` configuration scenarios.
  - This will allow us to remove the usage of duplicate keys in configuration for multiple conditions.
- Fix the CLI output displaying invalid conditions
- Invalid tests are added to `test/cli.js` in an unimplemented state.
