### PR TITLE
Throw for proofing errors by default, add flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint": "eslint src test",
     "test": "ava",
     "test:watch": "chokidar 'test/*.js' 'src/**' -c 'npm test' --silent --initial",
-    "integration-test": "npm run build && node cli.js test/fixtures/*.md test/fixtures/*.txt --no-throw",
+    "integration-test": "npm run build && node cli.js --no-throw test/fixtures/*.md test/fixtures/*.txt",
     "validate": "npm run lint && npm test",
     "prepare": "npm run build && npm run validate && npm run check",
     "prepublish": "npm run clean && npm run build"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint": "eslint src test",
     "test": "ava",
     "test:watch": "chokidar 'test/*.js' 'src/**' -c 'npm test' --silent --initial",
-    "integration-test": "npm run build && node cli.js test/fixtures/*.md test/fixtures/*.txt",
+    "integration-test": "npm run build && node cli.js test/fixtures/*.md test/fixtures/*.txt --no-throw",
     "validate": "npm run lint && npm test",
     "prepare": "npm run build && npm run validate && npm run check",
     "prepublish": "npm run clean && npm run build"

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,13 +20,13 @@ Options
   -t, --throw, --no-throw  Do not throw when errors are encountered.          [Default: ${defaultFlags.throw}]
 
 Examples
-  $ markdown-proofing ./file1.md',
-  Analyze ./file1.md file',
-  $ markdown-proofing ./file1.md ./file2.md',
-  Analyze ./file1.md and ./file2.md files',
-  $ markdown-proofing -c ./custom-configuration.json ./file1.md',
-  Analyze ./file.md file using ./custom-configuration.json',
-  $ markdown-proofing **/*.md',
+  $ markdown-proofing ./file1.md
+  Analyze ./file1.md file
+  $ markdown-proofing ./file1.md ./file2.md
+  Analyze ./file1.md and ./file2.md files
+  $ markdown-proofing -c ./custom-configuration.json ./file1.md
+  Analyze ./file.md file using ./custom-configuration.json
+  $ markdown-proofing **/*.md
   Analyze all .md files recursively`, {
     alias: {
       c: 'configuration',

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,7 +6,8 @@ import Main from './lib/main';
 
 const defaultFlags = {
   configuration: '.markdown-proofing',
-  color: true
+  color: true,
+  throw: true
 };
 
 const cli = meow(`
@@ -14,8 +15,9 @@ Usage
   $ markdown-proofing [...file-glob] [options]
 
 Options
-  -c, --configuration  Specify a configuration file to use.               [Default: ${defaultFlags.configuration}]
-  --color, --no-color  Specify if color should be applied to the output.  [Default: ${defaultFlags.color}]
+  -c, --configuration      Specify a configuration file to use.               [Default: ${defaultFlags.configuration}]
+  --color, --no-color      Specify if color should be applied to the output.  [Default: ${defaultFlags.color}]
+  -t, --throw, --no-throw  Do not throw when errors are encountered.          [Default: ${defaultFlags.throw}]
 
 Examples
   $ markdown-proofing ./file1.md',
@@ -27,7 +29,8 @@ Examples
   $ markdown-proofing **/*.md',
   Analyze all .md files recursively`, {
     alias: {
-      c: 'configuration'
+      c: 'configuration',
+      t: 'throw'
     },
     default: defaultFlags
   });

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,7 @@ const defaultFlags = {
 
 const cli = meow(`
 Usage
-  $ markdown-proofing [...file-glob] [options]
+  $ markdown-proofing [options] [...file-glob]
 
 Options
   -c, --configuration      Specify a configuration file to use.               [Default: ${defaultFlags.configuration}]

--- a/test/main.js
+++ b/test/main.js
@@ -180,3 +180,42 @@ test('Shows blue for info when color specified', t => {
     t.is(main.logger.messages[1], chalk.blue('[info] statistics-word-count : 198'));
   });
 });
+
+test('Does not throw for proofing errors by default', t => {
+  const configuration = {
+    analyzers: ['statistics'],
+    rules: { 'statistics-word-count': 'error' }
+  };
+
+  const main = getMain(configuration);
+
+  main.run().catch(() => {
+    t.fail();
+  });
+});
+
+test('Throws for one error by default with expected message', t => {
+  const configuration = {
+    analyzers: ['statistics'],
+    rules: { 'statistics-word-count': 'error' }
+  };
+
+  const main = getMain(configuration, { throw: true });
+
+  main.run().catch(e => {
+    t.is(e, ['Error: 1 error was encountered while proofing.']);
+  });
+});
+
+test('Throws for two errors by default with expected message', t => {
+  const configuration = {
+    analyzers: ['statistics'],
+    rules: { 'statistics-word-count': 'error' }
+  };
+
+  const main = getMain(configuration, { throw: true });
+
+  main.run().catch(e => {
+    t.is(e, ['Error: 2 errors were encountered while proofing.']);
+  });
+});


### PR DESCRIPTION
- Change the `cli.js` to throw by default for proofing errors
- Add a flag to control this setting
- `npm run integration-test` is set to not throw to avoid confusion (and, possibly issues with CI?)
- Remove unwanted characters from CLI help