### PR TITLE
Handle process.stdin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ script:
   - npm run build
   - npm run validate
   - npm run integration-test
+  - npm run integration-test-stdin
 after_success:
   - npm run coveralls

--- a/build.cmd
+++ b/build.cmd
@@ -9,6 +9,7 @@ call npm run build
 call npm run lint
 call npm run coverage:teamcity
 call npm run integration-test
+call npm run integration-test-stdin-windows
 
 if %ERRORLEVEL% neq 0 goto BuildFail
 goto BuildSuccess

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "test": "ava",
     "test:watch": "chokidar 'test/*.js' 'src/**' -c 'npm test' --silent --initial",
     "integration-test": "npm run build && node cli.js --no-throw test/fixtures/*.md test/fixtures/*.txt",
+    "integration-test-stdin": "npm run build && cat README.md | node cli.js --no-throw",
+    "integration-test-stdin-windows": "npm run build && type README.md | node cli.js --no-throw",
     "validate": "npm run lint && npm test",
     "prepare": "npm run build && npm run validate && npm run check",
     "prepublish": "npm run clean && npm run build"

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,7 @@
 
 import meow from 'meow';
 import JsonFileConfigurationProvider from './lib/jsonFileConfigurationProvider';
+import StdinHelper from './lib/stdin-helper';
 import Main from './lib/main';
 
 const defaultFlags = {
@@ -24,6 +25,8 @@ Examples
   Analyze ./file1.md file
   $ markdown-proofing ./file1.md ./file2.md
   Analyze ./file1.md and ./file2.md files
+  $ cat ./file1.md | markdown-proofing
+  Analyze text from standard input
   $ markdown-proofing -c ./custom-configuration.json ./file1.md
   Analyze ./file.md file using ./custom-configuration.json
   $ markdown-proofing **/*.md
@@ -35,18 +38,10 @@ Examples
     default: defaultFlags
   });
 
-const input = cli.input || [];
-const flags = cli.flags || {};
-
-if (!cli.input || cli.input.length === 0) {
-  console.log(cli.help); // eslint-disable-line no-console
-  process.exit(1); // eslint-disable-line no-process-exit
-}
-
 const main = new Main(
-  input,
-  flags,
-  new JsonFileConfigurationProvider(flags.configuration || '.markdown-proofing'),
-  console);
+  cli,
+  new JsonFileConfigurationProvider(cli.flags.configuration),
+  console,
+  new StdinHelper());
 
 main.run();

--- a/src/lib/stdin-helper.js
+++ b/src/lib/stdin-helper.js
@@ -1,0 +1,16 @@
+import fs from 'fs';
+
+export default class StdinHelper {
+  readAllSync() {
+    if (process.stdin.isTTY) {
+      return null;
+    }
+
+    // Adapted from http://stackoverflow.com/a/9318276
+    process.stdin.resume();
+    const response = fs.readSync(process.stdin.fd, 1000000000, 0, 'utf-8');
+    process.stdin.pause();
+
+    return response[0];
+  }
+}

--- a/test/main.js
+++ b/test/main.js
@@ -24,13 +24,81 @@ class TestLogger {
   }
 }
 
-function getMain(configuration, flags) {
-  return new Main(
-    [path.resolve(__dirname, '../test/fixtures/2015-12-20-announcing-rimdev-releases.md')],
-    flags || {},
-    new TestConfigurationProvider(configuration),
-    new TestLogger());
+class TestStdinHelper {
+  constructor(text) {
+    this.readAllSyncCalled = false;
+    this.text = text;
+  }
+
+  readAllSync() {
+    this.readAllSyncCalled = true;
+    return this.text;
+  }
 }
+
+const inputDefault = [
+  path.resolve(__dirname, '../test/fixtures/2015-12-20-announcing-rimdev-releases.md')
+];
+
+const testHelpMessage = 'test-help';
+
+function getMain(configuration, flags = {}, input = inputDefault, stdinText = null) {
+  const cli = {
+    input: input,
+    flags: flags,
+    help: testHelpMessage
+  };
+
+  return new Main(
+    cli,
+    new TestConfigurationProvider(configuration),
+    new TestLogger(),
+    new TestStdinHelper(stdinText));
+}
+
+test('Sends help message to logger when no files or stdin contents', t => {
+  const configuration = {
+    analyzers: ['statistics'],
+    rules: { 'statistics-word-count': 'info' }
+  };
+
+  const main = getMain(configuration, {}, []);
+
+  return main.run().then(() => {
+    t.is(main.logger.messages.length, 1);
+    t.is(main.logger.messages[0], testHelpMessage);
+  });
+});
+
+test('Reads from stdin when no files specified', t => {
+  const configuration = {
+    analyzers: ['statistics'],
+    rules: { 'statistics-letter-count': 'info' }
+  };
+
+  const stdinText = 'test';
+  const main = getMain(configuration, {}, [], stdinText);
+
+  return main.run().then(() => {
+    t.true(main.stdinHelper.readAllSyncCalled);
+
+    t.is(main.logger.messages.length, 2); // First message is the file printout
+    t.is(main.logger.messages[1], `[info] statistics-letter-count : ${stdinText.length}`);
+  });
+});
+
+test('Does not read from stdin when any files specified', t => {
+  const configuration = {
+    analyzers: ['statistics'],
+    rules: { 'statistics-word-count': 'info' }
+  };
+
+  const main = getMain(configuration);
+
+  return main.run().then(() => {
+    t.false(main.stdinHelper.readAllSyncCalled);
+  });
+});
 
 test('Returns expected error when warning exists applying error first', t => {
   const configuration = {


### PR DESCRIPTION
Allow usage of `process.stdin`. `process.stdin` is only inspected when no files are specified.
