### PR TITLE
Update test to support Node.js 6.1.0

### DIFF
--- a/test/jsonFileConfigurationProvider.js
+++ b/test/jsonFileConfigurationProvider.js
@@ -30,7 +30,7 @@ test('getConfiguration should throw for invalid JSON', t => {
 
   const provider = new JsonFileConfigurationProvider(testFilePath);
 
-  t.throws(() => provider.getConfiguration(), 'Unexpected token T');
+  t.throws(() => provider.getConfiguration(), /Unexpected token T/);
 });
 
 test('getConfiguration should return expected configuration when valid JSON', t => {


### PR DESCRIPTION
Error message is showing `Unexpected token T in JSON at position 0` on Node.js 6.1.0.