### PR TITLE
Allow rule overrides

### DIFF
--- a/src/lib/markdownProofing.js
+++ b/src/lib/markdownProofing.js
@@ -43,7 +43,12 @@ export default class MarkdownProofing {
           markdownProofing.rules = markdownProofing.rules.filter(
             x => x.messageType !== prop);
         } else {
-          markdownProofing.addRule(prop, ruleValue);
+          if (markdownProofing.ruleExists(prop)) {
+            markdownProofing.updateRule(prop, ruleValue);
+          }
+          else {
+            markdownProofing.addRule(prop, ruleValue);
+          }
         }
       }
     }
@@ -108,5 +113,17 @@ export default class MarkdownProofing {
         messages: analyzerMessages
       };
     });
+  }
+
+  ruleExists(messageType) {
+    var existingRules = this.rules.filter(x => x.messageType === messageType);
+
+    return existingRules.length > 0;
+  }
+  
+  updateRule(messageType, ruleCondition) {
+    this.rules = this.rules.filter(x => x.messageType !== messageType);
+
+    return this.addRule(messageType, ruleCondition);
   }
 }

--- a/test/markdownProofing.js
+++ b/test/markdownProofing.js
@@ -194,3 +194,29 @@ test('createUsingConfiguration removes rules from preset with none', t => {
 
   t.false(proofing.rules.some(x => x.messageType === 'spelling-error'));
 });
+
+test('Inline rules override preset rules', t => {
+  const configurationBaseline = {
+    presets: [
+      'inline-rule'
+    ]
+  };
+
+  const configuration = {
+    presets: [
+      'inline-rule'
+    ],
+    rules: {
+      'spelling-error': 'info'
+    }
+  };
+
+  const proofingBaseline = MarkdownProofing.createUsingConfiguration(configurationBaseline, __dirname);
+  const proofing = MarkdownProofing.createUsingConfiguration(configuration, __dirname);
+
+  t.true(proofingBaseline.rules.filter(x => x.messageType === 'spelling-error').length === 1);
+  t.true(proofingBaseline.rules.filter(x => x.messageType === 'spelling-error')[0].condition === 'error');
+  
+  t.true(proofing.rules.filter(x => x.messageType === 'spelling-error').length === 1);
+  t.true(proofing.rules.filter(x => x.messageType === 'spelling-error')[0].condition === 'info');
+});

--- a/test/presets/inline-rule.json
+++ b/test/presets/inline-rule.json
@@ -1,0 +1,5 @@
+{  
+  "rules": {    
+    "spelling-error": "error"
+  }
+}


### PR DESCRIPTION
New behavior allows inline rules within cli config. to override preset rules.
Previous behavior just added the former to the rules collection. Therefore, the latter would always take precedence.